### PR TITLE
set trigger to main branch

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-forest-0fc346b0f.yml
+++ b/.github/workflows/azure-static-web-apps-kind-forest-0fc346b0f.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - jloucks-cat-hello
+      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - jloucks-cat-hello
+      - main
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
Set the github action trigger for static website deployment to main branch from john-cat branch so that it triggers on any pushes to main. 